### PR TITLE
Add .gitignore file

### DIFF
--- a/go-log-seeker/.gitignore
+++ b/go-log-seeker/.gitignore
@@ -1,0 +1,28 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Logs
+*.log
+
+# Dependency directories
+vendor/
+
+# Go workspace file
+go.work
+
+# IDE/editor specific files
+.vscode/
+.idea/
+*.swp
+*.swo
+*.swn
+
+# OS generated files
+.DS_Store
+Thumbs.db

--- a/go-log-seeker/.gitignore.license
+++ b/go-log-seeker/.gitignore.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OCode
+#
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This pull request includes updates to the `.gitignore` file in the `go-log-seeker` project to ensure that unnecessary files are not tracked by Git.

### Updates to `.gitignore` file:

* Added patterns to ignore binary files, such as `*.exe`, `*.dll`, `*.so`, and `*.dylib`.
* Added patterns to ignore output files from the Go coverage tool, specifically `*.out`.
* Added patterns to ignore log files, such as `*.log`.
* Added patterns to ignore dependency directories, specifically `vendor/`.
* Added patterns to ignore Go workspace file `go.work`.
* Added patterns to ignore IDE/editor specific files, such as `.vscode/`, `.idea/`, `*.swp`, `*.swo`, and `*.swn`.
* Added patterns to ignore OS generated files, such as `.DS_Store` and `Thumbs.db`.